### PR TITLE
Add radar with fast travel

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ Movement has inertia, so you'll drift through space unless you counter-thrust.
 Enemy ships spawn at random and will fire at you. Press **Space** or click the
 mouse to shoot back. Each planet and enemy uses a unique procedurally created
 texture.
-¡
+Press **M** to open a small radar that shows nearby planets. Clicking a planet
+on the radar instantly warps your ship to its location.
 
 Planets belong to solar systems orbiting colorful stars. Their gravity pulls on
 the player, and landing fully recharges your health. Some worlds also replenish
-fuel, oxygen and food, which slowly run out as you explore. The game code is
+fuel, oxygen and food, which slowly run out as you explore. Fuel capacity is now
+1000 times larger for long journeys. The game code is
 split into small ES modules inside the `modules` folder for clarity. Health and
 resource bars from 0&ndash;100% are shown in the upper left, along with your
 current X,Y coordinates. The map is infinite, so wander as far as you like. An

--- a/modules/engine.js
+++ b/modules/engine.js
@@ -140,7 +140,7 @@ export function update() {
       const dist = Math.hypot(dx, dy);
       if (dist < p.size + 12) {
         landed = true;
-        if (p.supplies.fuel) state.resources.fuel = state.maxResource;
+        if (p.supplies.fuel) state.resources.fuel = state.maxFuel;
         if (p.supplies.oxygen) state.resources.oxygen = state.maxResource;
         if (p.supplies.food) state.resources.food = state.maxResource;
       }
@@ -247,21 +247,24 @@ export function draw() {
   ctx.fillStyle = 'grey';
   ctx.fillRect(20, 40, 104, 14);
   ctx.fillStyle = 'orange';
-  ctx.fillRect(22, 42, state.resources.fuel, 10);
+  const fuelWidth = (state.resources.fuel / state.maxFuel) * 100;
+  ctx.fillRect(22, 42, fuelWidth, 10);
   ctx.strokeStyle = 'white';
   ctx.strokeRect(20, 40, 104, 14);
 
   ctx.fillStyle = 'grey';
   ctx.fillRect(20, 60, 104, 14);
   ctx.fillStyle = 'aqua';
-  ctx.fillRect(22, 62, state.resources.oxygen, 10);
+  const oxyWidth = (state.resources.oxygen / state.maxResource) * 100;
+  ctx.fillRect(22, 62, oxyWidth, 10);
   ctx.strokeStyle = 'white';
   ctx.strokeRect(20, 60, 104, 14);
 
   ctx.fillStyle = 'grey';
   ctx.fillRect(20, 80, 104, 14);
   ctx.fillStyle = 'magenta';
-  ctx.fillRect(22, 82, state.resources.food, 10);
+  const foodWidth = (state.resources.food / state.maxResource) * 100;
+  ctx.fillRect(22, 82, foodWidth, 10);
   ctx.strokeStyle = 'white';
   ctx.strokeRect(20, 80, 104, 14);
 
@@ -283,6 +286,41 @@ export function draw() {
     20,
     canvas.height - 20
   );
+
+  if (state.showRadar) {
+    const size = state.radarSize;
+    const radius = state.radarRadius;
+    const rx = canvas.width - size - 20;
+    const ry = 20;
+    ctx.fillStyle = 'rgba(0,0,0,0.5)';
+    ctx.fillRect(rx, ry, size, size);
+    ctx.strokeStyle = 'white';
+    ctx.strokeRect(rx, ry, size, size);
+    ctx.fillStyle = 'cyan';
+    ctx.fillRect(rx + size / 2 - 2, ry + size / 2 - 2, 4, 4);
+    state.radarTargets = [];
+    const systems = getNearbySystems(state, radius);
+    for (const s of systems) {
+      for (const p of s.planets) {
+        const angle = p.phase + state.tick * p.speed;
+        const px = s.x + Math.cos(angle) * p.orbit;
+        const py = s.y + Math.sin(angle) * p.orbit;
+        const dx = (px - state.playerX) / radius;
+        const dy = (py - state.playerY) / radius;
+        if (Math.abs(dx) <= 1 && Math.abs(dy) <= 1) {
+          const sx = rx + size / 2 + dx * size / 2;
+          const sy = ry + size / 2 + dy * size / 2;
+          ctx.fillStyle = 'orange';
+          ctx.beginPath();
+          ctx.arc(sx, sy, 3, 0, Math.PI * 2);
+          ctx.fill();
+          state.radarTargets.push({ sx, sy, x: px, y: py });
+        }
+      }
+    }
+  } else {
+    state.radarTargets = [];
+  }
 
   requestAnimationFrame(draw);
 }

--- a/modules/input.js
+++ b/modules/input.js
@@ -2,50 +2,80 @@ import { canvas, state } from './state.js';
 
 let shootFunc = () => {};
 
-function handleKey(e) {
-  switch (e.key) {
+function setKey(key, val) {
+  switch (key) {
     case 'ArrowUp':
     case 'w':
     case 'W':
-
-      state.playerY -= state.speed;
-      state.resources.fuel = Math.max(0, state.resources.fuel - 0.5);
+      state.keys.up = val;
       break;
     case 'ArrowDown':
     case 's':
     case 'S':
-
-      state.playerY += state.speed;
-      state.resources.fuel = Math.max(0, state.resources.fuel - 0.5);
+      state.keys.down = val;
       break;
     case 'ArrowLeft':
     case 'a':
     case 'A':
-
-      state.playerX -= state.speed;
-      state.resources.fuel = Math.max(0, state.resources.fuel - 0.5);
+      state.keys.left = val;
       break;
     case 'ArrowRight':
     case 'd':
     case 'D':
-
-      state.playerX += state.speed;
-      state.resources.fuel = Math.max(0, state.resources.fuel - 0.5);
-      break;
-    case ' ':
-      shootFunc();
+      state.keys.right = val;
       break;
   }
 }
 
+function handleKeyDown(e) {
+  if (e.key === ' ') {
+    shootFunc();
+  } else if (e.key === 'm' || e.key === 'M') {
+    state.showRadar = !state.showRadar;
+  } else {
+    setKey(e.key, true);
+  }
+}
+
+function handleKeyUp(e) {
+  setKey(e.key, false);
+}
+
+function handleRadarClick(e) {
+  const { radarSize, radarTargets } = state;
+  const rx = canvas.width - radarSize - 20;
+  const ry = 20;
+  if (e.offsetX < rx || e.offsetX > rx + radarSize || e.offsetY < ry || e.offsetY > ry + radarSize) {
+    return;
+  }
+  for (const t of radarTargets) {
+    const dx = e.offsetX - t.sx;
+    const dy = e.offsetY - t.sy;
+    if (dx * dx + dy * dy < 25) {
+      state.playerX = t.x;
+      state.playerY = t.y;
+      state.playerVX = 0;
+      state.playerVY = 0;
+      state.showRadar = false;
+      break;
+    }
+  }
+}
 
 export function setupInput(shoot) {
   shootFunc = shoot;
-  document.addEventListener('keydown', handleKey);
+  document.addEventListener('keydown', handleKeyDown);
+  document.addEventListener('keyup', handleKeyUp);
 
   canvas.addEventListener('mousemove', e => {
     state.mouseX = e.offsetX;
     state.mouseY = e.offsetY;
   });
-  canvas.addEventListener('click', shootFunc);
+  canvas.addEventListener('click', e => {
+    if (state.showRadar) {
+      handleRadarClick(e);
+    } else {
+      shootFunc();
+    }
+  });
 }

--- a/modules/state.js
+++ b/modules/state.js
@@ -1,12 +1,23 @@
 export const canvas = document.getElementById('game');
 export const ctx = canvas.getContext('2d');
 
+canvas.width = window.innerWidth;
+canvas.height = window.innerHeight;
+window.addEventListener('resize', () => {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+});
+
 
 export const state = {
   playerX: 0,
   playerY: 0,
+  playerVX: 0,
+  playerVY: 0,
+  angle: 0,
   playerHealth: 100,
-  resources: { fuel: 100, oxygen: 100, food: 100 },
+  resources: { fuel: 100000, oxygen: 100, food: 100 },
+  maxFuel: 100000,
   maxResource: 100,
   speed: 4,
 
@@ -19,4 +30,9 @@ export const state = {
   tick: 0,
   mouseX: canvas.width / 2,
   mouseY: canvas.height / 2,
+  keys: { up: false, down: false, left: false, right: false },
+  showRadar: false,
+  radarSize: 150,
+  radarRadius: 3000,
+  radarTargets: [],
 };


### PR DESCRIPTION
## Summary
- show radar overlay with `M` key
- click planets in the radar to warp instantly
- track radar state and targets
- expand fuel capacity 1000x and scale resource bars

## Testing
- `node --check game.js`
- `node --check modules/engine.js`
- `node --check modules/input.js`
- `node --check modules/state.js`
- `node --check modules/intro.js`
- `node --check modules/textures.js`
- `node --check modules/util.js`
- `node --check modules/world.js`


------
https://chatgpt.com/codex/tasks/task_e_685b084863888331b5b4181fed3bb282