### PR TITLE
Handle planetary turret targeting and landing center

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@ This project is a small browser game written in plain JavaScript. It renders an 
 
 - **Movement:** Use the arrow keys or **WASD** to control your thrusters. Movement has inertia so you'll drift unless you counter-thrust.
 - **Combat:** Press **Space** or click to fire your cannons. Weapons build heat and temporarily lock when the meter reaches 100%, so let them cool before shooting again.
-- **Landing:** Press **E** near a planet to land. A short animation moves the ship down once you are within 10% of the planet's radius. Landed vendor worlds automatically trade Ore for credits and may offer randomized cargo delivery missions.
+- **Landing:** Press **E** near a planet to land. A short animation moves the ship to the planet's center once you are within 10% of its radius. Landed vendor worlds automatically trade Ore for credits and may offer randomized cargo delivery missions.
 - **Harvesting & Building:** While landed press **H** to gather Metal and Carbon on resource worlds. Press **B** to place a base module (requires 10 Ore, 5 Metal and 5 Carbon) and **R** to rotate it. Bases are stored locally and appear as brown squares on planets and on the radar.
 - **Radar:** A minimap in the upper right shows nearby planets and clicking one instantly warps your ship to its location.
 
 ## World Generation
 
-- Stars are spaced about **500 units** apart. Each system hosts between one and nine planets on wide, non‑colliding orbits.
+ - Stars appear randomly between **500** and **2000** units from the previous system and are generated outside your view. Each system hosts between one and nine planets on wide, non‑colliding orbits.
 - Planet sizes vary with a standard deviation near 100 units. Planet colors hint at available resources. Some planets replenish fuel, oxygen or food when you land.
 - Enemy ships spawn roughly every thirty seconds and take 5–15 shots to destroy, rewarding **200 credits** each.
-- Planets are protected by 1–10 defense turrets depending on size. Turrets have 3–10 hit points and a one‑second cooldown between shots, so they pause briefly before firing again.
+- Planets are protected by 1–10 defense turrets depending on size. Turrets have 3–10 hit points and a one‑second cooldown between shots, opening fire on your ship if you fly within ten planetary radii.
 - Clearing all turrets on a planet and landing there for the first time upgrades your ship with additional cannons, letting you fire more bullets at once.
 
 ## Miscellaneous

--- a/modules/engine.js
+++ b/modules/engine.js
@@ -1,6 +1,6 @@
 import { state, ctx, canvas, resetState } from './state.js';
 import { generatePlanetTexture, generateShipTexture } from './textures.js';
-import { drawStarfieldTile, getNearbySystems, findNearestStar, ensurePlanetTurrets, ensureStarNear } from './world.js';
+import { drawStarfieldTile, getNearbySystems, findNearestStar, getStarSystem, ensurePlanetTurrets, ensureStarNear } from './world.js';
 
 
 import { playIntro } from './intro.js';
@@ -10,7 +10,13 @@ const TURRET_COOLDOWN_FRAMES = 60; // turret fires about once per second
 
 export function shoot() {
   if (state.isOverheated || state.weaponHeat >= state.maxHeat) {
-    if (state.weaponHeat >= state.maxHeat) state.isOverheated = true;
+    if (state.weaponHeat >= state.maxHeat) {
+      state.isOverheated = true;
+      if (state.messageTimer <= 0) {
+        state.message = 'Weapons overheated!';
+        state.messageTimer = 60;
+      }
+    }
     return;
   }
   const angle = Math.atan2(
@@ -47,7 +53,7 @@ function spawnEnemy() {
   });
 }
 
-function ensurePlanetTurrets() {
+function refreshPlanetTurrets() {
   const systems = getNearbySystems(state, state.radarRadius * 2);
   for (const s of systems) {
     for (const p of s.planets) {
@@ -178,12 +184,9 @@ export function toggleLanding() {
   }
   if (closest && closest.dist <= closest.p.size * 1.1) {
     const { s, p, px, py } = closest;
-    const dx = state.playerX - px;
-    const dy = state.playerY - py;
-    const ang = Math.atan2(dy, dx);
     state.landing = {
-      targetX: px + Math.cos(ang) * p.size,
-      targetY: py + Math.sin(ang) * p.size,
+      targetX: px,
+      targetY: py,
       frames: 30,
       star: s,
       planet: p,
@@ -291,7 +294,7 @@ export function update() {
   if (state.tick > 0 && state.tick % ENEMY_SPAWN_FRAMES === 0) {
     spawnEnemy();
   }
-  ensurePlanetTurrets();
+  refreshPlanetTurrets();
 
   for (const t of state.planetTurrets) {
     const star = getStarSystem(t.gx, t.gy);
@@ -304,23 +307,16 @@ export function update() {
     t.x = px + Math.cos(ta) * (p.size + 40);
     t.y = py + Math.sin(ta) * (p.size + 40);
     if (t.cooldown > 0) t.cooldown -= 1;
-    let target = null;
-    for (const e of state.enemies) {
-      const dx = e.x - t.x;
-      const dy = e.y - t.y;
-      const dist = Math.hypot(dx, dy);
-      if (dist < 600) {
-        target = { dx, dy, dist };
-        break;
-      }
-    }
-    if (target && t.cooldown <= 0) {
+    const dx = state.playerX - t.x;
+    const dy = state.playerY - t.y;
+    const dist = Math.hypot(dx, dy);
+    if (dist < p.size * 10 && t.cooldown <= 0) {
       const bulletSpeed = 8;
       state.bullets.push({
         x: t.x,
         y: t.y,
-        vx: (target.dx / target.dist) * bulletSpeed,
-        vy: (target.dy / target.dist) * bulletSpeed,
+        vx: (dx / dist) * bulletSpeed,
+        vy: (dy / dist) * bulletSpeed,
       });
       t.cooldown = 20;
     }
@@ -834,7 +830,6 @@ export function draw() {
 
   ctx.fillStyle = 'grey';
   ctx.fillStyle = state.isOverheated ? 'red' : 'orange';
-  if (state.isOverheated) {
   ctx.fillRect(22, 22, state.playerHealth, 10);
   ctx.strokeStyle = 'white';
   ctx.strokeRect(20, 20, 104, 14);
@@ -966,12 +961,7 @@ export function draw() {
     if (nearest) {
       let dx = (nearest.x - state.playerX) / radius;
       let dy = (nearest.y - state.playerY) / radius;
-  if (state.isRestarting) {
-    state.isRestarting = false;
-    restartGame();
-  } else {
-    requestAnimationFrame(draw);
-  }
+      const mag = Math.hypot(dx, dy);
       if (mag > 1) {
         dx /= mag;
         dy /= mag;
@@ -1003,5 +993,4 @@ export function draw() {
   } else {
     requestAnimationFrame(draw);
   }
-}
 }

--- a/modules/state.js
+++ b/modules/state.js
@@ -57,6 +57,7 @@ export const state = {
   buildRotation: 0,
   buildings: JSON.parse(localStorage.getItem('buildings') || '[]'),
   turrets: {},
+  planetTurrets: [],
 
 
 };
@@ -99,6 +100,7 @@ export function resetState() {
     mission: null,
     buildRotation: 0,
     turrets: {},
+    planetTurrets: [],
 
   });
 }


### PR DESCRIPTION
## Summary
- planet turrets now shoot only at the player
- landing animation moves the ship to the planet's center
- note these behaviors in the README

## Testing
- `node --check modules/engine.js`
- `node -e "import('./modules/engine.js').then(()=>console.log('loaded')).catch(e=>console.log('err',e.message))"`

------
https://chatgpt.com/codex/tasks/task_e_685db1bc12d483319f00ae49efc63d23