### PR TITLE
Handle planetary turret targeting and landing center

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@ This project is a small browser game written in plain JavaScript. It renders an 
 ## Gameplay
 
 - **Movement:** Use the arrow keys or **WASD** to control your thrusters. Movement has inertia so you'll drift unless you counter-thrust.
-- **Combat:** Press **Space** or click to fire your cannons. Weapons build heat and temporarily lock when the meter reaches 100%, so let them cool before shooting again.
-- **Landing:** Press **E** near a planet to land. A short animation moves the ship down once you are within 10% of the planet's radius. Landed vendor worlds automatically trade Ore for credits and may offer randomized cargo delivery missions.
+- **Combat:** Press **Space** or click to fire your cannons. Weapons build heat and lock for about three seconds if they overheat, so watch the meter.
+- **Landing:** Press **E** near a planet to land. A short animation moves the ship to the planet's center once you are within 10% of its radius. Landed vendor worlds automatically trade Ore for credits and may offer randomized cargo delivery missions.
 - **Harvesting & Building:** While landed press **H** to gather Metal and Carbon on resource worlds. Press **B** to place a base module (requires 10 Ore, 5 Metal and 5 Carbon) and **R** to rotate it. Bases are stored locally and appear as brown squares on planets and on the radar.
 - **Radar:** A minimap in the upper right shows nearby planets and clicking one instantly warps your ship to its location.
 
 ## World Generation
 
-- Stars are spaced about **500 units** apart. Each system hosts between one and nine planets on wide, non‑colliding orbits.
+ - Stars appear randomly between **500** and **2000** units from the previous system and are generated outside your view. Each system hosts between one and nine planets on wide, non‑colliding orbits.
 - Planet sizes vary with a standard deviation near 100 units. Planet colors hint at available resources. Some planets replenish fuel, oxygen or food when you land.
 - Enemy ships spawn roughly every thirty seconds and take 5–15 shots to destroy, rewarding **200 credits** each.
-- Planets are protected by 1–10 defense turrets depending on size. Turrets have 3–10 hit points and a one‑second cooldown between shots, so they pause briefly before firing again.
+- Planets are protected by 1–10 defense turrets depending on size. Turrets have 3–10 hit points and a one‑second cooldown between shots, opening fire on your ship if you fly within ten planetary radii.
 - Clearing all turrets on a planet and landing there for the first time upgrades your ship with additional cannons, letting you fire more bullets at once.
 
 ## Miscellaneous

--- a/modules/state.js
+++ b/modules/state.js
@@ -28,6 +28,7 @@ export const state = {
   weaponHeat: 0,
   isOverheated: false,
   maxHeat: 100,
+  overheatTimer: 0,
   tick: 0,
   mouseX: canvas.width / 2,
   mouseY: canvas.height / 2,
@@ -57,6 +58,7 @@ export const state = {
   buildRotation: 0,
   buildings: JSON.parse(localStorage.getItem('buildings') || '[]'),
   turrets: {},
+  planetTurrets: [],
 
 
 };
@@ -75,6 +77,7 @@ export function resetState() {
     enemyBullets: [],
     weaponHeat: 0,
     isOverheated: false,
+    overheatTimer: 0,
     tick: 0,
     mouseX: canvas.width / 2,
     mouseY: canvas.height / 2,
@@ -99,6 +102,7 @@ export function resetState() {
     mission: null,
     buildRotation: 0,
     turrets: {},
+    planetTurrets: [],
 
   });
 }


### PR DESCRIPTION
## Summary
- planet turrets now shoot only at the player
- landing animation moves the ship to the planet's center
- note these behaviors in the README
- block firing for 3 seconds after overheating

## Testing
- `node --check modules/engine.js`
- `node -e "import('./modules/engine.js').then(()=>console.log('loaded')).catch(e=>console.log('err',e.message))"`

------
https://chatgpt.com/codex/tasks/task_e_685db1bc12d483319f00ae49efc63d23